### PR TITLE
Add WatermarkPayload.from_bytes and decode watermark metadata

### DIFF
--- a/src/drmstego/cli.py
+++ b/src/drmstego/cli.py
@@ -1,9 +1,10 @@
+import json
+
 import typer
-from pathlib import Path
-from PIL import Image
-from .steg.lsb import LSBStego
+
+from .drm.watermark import WatermarkPayload, make_simple_watermark
 from .io_utils import read_image, save_image
-from .drm.watermark import make_simple_watermark
+from .steg.lsb import LSBStego
 
 app = typer.Typer(help="隐写-版权 研究用 CLI")
 
@@ -21,7 +22,11 @@ def extract(stego: str, length: int):
     """从图像中提取固定长度字节"""
     img = read_image(stego)
     data = LSBStego().extract(img, length_bytes=length)
-    typer.echo(data.decode("utf-8", errors="ignore"))
+    try:
+        wm = WatermarkPayload.from_bytes(data)
+        typer.echo(json.dumps(wm.__dict__, ensure_ascii=False))
+    except ValueError:
+        typer.echo(data.decode("utf-8", errors="ignore"))
 
 @app.command()
 def embed_license(cover: str, out: str, author: str, license_id: str):

--- a/src/drmstego/drm/watermark.py
+++ b/src/drmstego/drm/watermark.py
@@ -1,6 +1,7 @@
+import json
 from dataclasses import dataclass
 from datetime import datetime
-import json
+
 
 @dataclass
 class WatermarkPayload:
@@ -17,8 +18,30 @@ class WatermarkPayload:
             "extra": self.extra,
         }, ensure_ascii=False).encode("utf-8")
 
+    @classmethod
+    def from_bytes(cls, data: bytes) -> "WatermarkPayload":
+        try:
+            obj = json.loads(data.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
+            raise ValueError("Invalid watermark payload") from e
+        if not isinstance(obj, dict):
+            raise ValueError("Invalid watermark payload")
+        try:
+            author = obj["author"]
+            license_id = obj["license_id"]
+            issued_at = obj["issued_at"]
+            extra = obj.get("extra", {})
+        except KeyError as e:
+            raise ValueError("Missing field in watermark payload") from e
+        if not isinstance(extra, dict):
+            raise ValueError("Invalid watermark payload")
+        return cls(author=author, license_id=license_id, issued_at=issued_at, extra=extra)
+
 def make_simple_watermark(author: str, license_id: str, **extra) -> bytes:
-    wm = WatermarkPayload(author=author, license_id=license_id,
-                          issued_at=datetime.utcnow().isoformat()+"Z",
-                          extra=extra)
+    wm = WatermarkPayload(
+        author=author,
+        license_id=license_id,
+        issued_at=datetime.utcnow().isoformat() + "Z",
+        extra=extra,
+    )
     return wm.to_bytes()

--- a/src/drmstego/steg/lsb.py
+++ b/src/drmstego/steg/lsb.py
@@ -1,6 +1,8 @@
-from PIL import Image
 import numpy as np
+from PIL import Image
+
 from .base import StegoAlgorithm
+
 
 class LSBStego(StegoAlgorithm):
     """简单LSB图像隐写（演示用，非生产）"""
@@ -14,7 +16,7 @@ class LSBStego(StegoAlgorithm):
         if bits.size > capacity:
             raise ValueError(f"载荷过大：{bits.size}bits > 容量{capacity}bits")
         flat = arr[:, :, channel].flatten()
-        flat[: bits.size] = (flat[: bits.size] & ~1) | bits
+        flat[: bits.size] = (flat[: bits.size] & np.uint8(0xFE)) | bits
         arr[:, :, channel] = flat.reshape(h, w)
         return Image.fromarray(arr)
 

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -1,9 +1,12 @@
-from fastapi import FastAPI, UploadFile
-from PIL import Image
 from io import BytesIO
+
+from fastapi import FastAPI, Form, UploadFile
+from PIL import Image
+
+from drmstego.drm.watermark import WatermarkPayload
 from drmstego.steg.lsb import LSBStego
 
-from .schemas import EmbedRequest, ExtractRequest
+from .schemas import EmbedRequest
 
 app = FastAPI(title="DRM Stego API", version="0.1.0")
 
@@ -21,7 +24,11 @@ async def embed(img: UploadFile, req: EmbedRequest):
     return {"image_bytes": list(buf.getvalue()), "length": len(req.text.encode('utf-8'))}
 
 @app.post("/extract")
-async def extract(img: UploadFile, req: ExtractRequest):
+async def extract(img: UploadFile, length: int = Form(...)):
     image = Image.open(BytesIO(await img.read())).convert("RGB")
-    data = LSBStego().extract(image, length_bytes=req.length)
-    return {"text": data.decode("utf-8", errors="ignore")}
+    data = LSBStego().extract(image, length_bytes=length)
+    try:
+        wm = WatermarkPayload.from_bytes(data)
+        return {"watermark": wm.__dict__}
+    except ValueError:
+        return {"text": data.decode("utf-8", errors="ignore")}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,11 @@
-from fastapi.testclient import TestClient
-from src.server.main import app
-from PIL import Image
 from io import BytesIO
+
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from drmstego.drm.watermark import make_simple_watermark
+from drmstego.steg.lsb import LSBStego
+from server.main import app
 
 client = TestClient(app)
 
@@ -10,8 +14,16 @@ def test_health():
     assert r.json()["ok"] is True
 
 def test_embed_extract():
-    img = Image.new("RGB", (64,64), color=(100,100,100))
-    buf = BytesIO(); img.save(buf, format="PNG"); buf.seek(0)
-    r = client.post("/embed", files={"img": ("a.png", buf.getvalue(), "image/png")},
-                    json={"text":"abc"})
+    img = Image.new("RGB", (64, 64), color=(100, 100, 100))
+    payload = make_simple_watermark("Alice", "L1")
+    stego = LSBStego().embed(img, payload)
+    buf = BytesIO()
+    stego.save(buf, format="PNG")
+    buf.seek(0)
+    r = client.post(
+        "/extract",
+        files={"img": ("a.png", buf.getvalue(), "image/png")},
+        data={"length": len(payload)},
+    )
     assert r.status_code == 200
+    assert r.json()["watermark"]["author"] == "Alice"

--- a/tests/test_lsb.py
+++ b/tests/test_lsb.py
@@ -1,5 +1,7 @@
 from PIL import Image
+
 from drmstego.steg.lsb import LSBStego
+
 
 def test_lsb_roundtrip():
     img = Image.new("RGB", (64, 64), color=(123, 222, 111))

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -1,0 +1,19 @@
+import pytest
+
+from drmstego.drm.watermark import WatermarkPayload
+
+
+def test_watermark_roundtrip():
+    wm = WatermarkPayload(
+        author="Alice",
+        license_id="LIC123",
+        issued_at="2023-01-01Z",
+        extra={"note": "hi"},
+    )
+    data = wm.to_bytes()
+    parsed = WatermarkPayload.from_bytes(data)
+    assert parsed == wm
+
+def test_watermark_invalid_bytes():
+    with pytest.raises(ValueError):
+        WatermarkPayload.from_bytes(b"not-json")


### PR DESCRIPTION
## Summary
- add `WatermarkPayload.from_bytes` to rebuild watermark payloads from raw bytes
- parse extracted bytes in CLI and API to return structured watermark info
- add unit tests for payload parsing and API extraction

## Testing
- `ruff check src/drmstego/drm/watermark.py src/drmstego/cli.py src/server/main.py src/drmstego/steg/lsb.py tests/test_api.py tests/test_watermark.py tests/test_lsb.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68b0604680648322afcb536860bea489