### PR TITLE
Implement Ed25519 license token signing and verification

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ scipy
 scikit-image
 pydantic>=2
 typer
+pynacl
+httpx
+python-multipart

--- a/src/drmstego/cli.py
+++ b/src/drmstego/cli.py
@@ -4,6 +4,11 @@ from PIL import Image
 from .steg.lsb import LSBStego
 from .io_utils import read_image, save_image
 from .drm.watermark import make_simple_watermark
+from .drm.license_token import (
+    sign_token as sign_token_bytes,
+    verify_token as verify_token_bytes,
+    SIGNATURE_LEN,
+)
 
 app = typer.Typer(help="隐写-版权 研究用 CLI")
 
@@ -31,6 +36,26 @@ def embed_license(cover: str, out: str, author: str, license_id: str):
     stego = LSBStego().embed(img, payload)
     save_image(stego, out)
     typer.echo(f"写入license水印完成：{out}（长度 {len(payload)} 字节）")
+
+
+@app.command("sign-token")
+def sign_token_cli(payload: str):
+    """对payload进行签名并输出token(hex)"""
+
+    token = sign_token_bytes(payload.encode("utf-8"))
+    typer.echo(token.hex())
+
+
+@app.command("verify-token")
+def verify_token_cli(token_hex: str):
+    """验证token并显示payload"""
+
+    token = bytes.fromhex(token_hex)
+    if verify_token_bytes(token):
+        payload = token[:-SIGNATURE_LEN].decode("utf-8", errors="ignore")
+        typer.echo(f"有效签名: {payload}")
+    else:
+        typer.echo("签名无效")
 
 if __name__ == "__main__":
     app()

--- a/src/drmstego/drm/license_token.py
+++ b/src/drmstego/drm/license_token.py
@@ -1,6 +1,43 @@
 # 轻量级占位：后续可用非对称签名（Ed25519）做许可证防伪
+"""License token helpers using Ed25519 signatures.
+
+Token structure: ``payload || signature`` where signature is 64 bytes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from nacl.signing import SigningKey
+from nacl.exceptions import BadSignatureError
+
+# Ed25519 signature length in bytes
+SIGNATURE_LEN = 64
+
+# 使用固定seed以便测试和多进程稳定
+_seed = hashlib.sha256(b"drmstego-ed25519-secret").digest()
+_signing_key = SigningKey(_seed)
+_verify_key = _signing_key.verify_key
+
+
 def sign_token(payload: bytes) -> bytes:
-    return payload  # TODO: 替换为真实签名
+    """Return ``payload`` appended with an Ed25519 signature."""
+
+    signature = _signing_key.sign(payload).signature
+    return payload + signature
+
 
 def verify_token(token: bytes) -> bool:
-    return True     # TODO: 校验签名
+    """Verify token consisting of ``payload || signature``.
+
+    Returns ``True`` when the signature is valid, otherwise ``False``.
+    """
+
+    if len(token) <= SIGNATURE_LEN:
+        return False
+    payload, sig = token[:-SIGNATURE_LEN], token[-SIGNATURE_LEN:]
+    try:
+        _verify_key.verify(payload, sig)
+        return True
+    except BadSignatureError:
+        return False
+

--- a/src/drmstego/steg/lsb.py
+++ b/src/drmstego/steg/lsb.py
@@ -14,7 +14,7 @@ class LSBStego(StegoAlgorithm):
         if bits.size > capacity:
             raise ValueError(f"载荷过大：{bits.size}bits > 容量{capacity}bits")
         flat = arr[:, :, channel].flatten()
-        flat[: bits.size] = (flat[: bits.size] & ~1) | bits
+        flat[: bits.size] = (flat[: bits.size] & np.uint8(0xFE)) | bits
         arr[:, :, channel] = flat.reshape(h, w)
         return Image.fromarray(arr)
 

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -1,9 +1,14 @@
-from fastapi import FastAPI, UploadFile
+from fastapi import FastAPI, UploadFile, Form
 from PIL import Image
 from io import BytesIO
 from drmstego.steg.lsb import LSBStego
+from drmstego.drm.license_token import (
+    sign_token as sign_token_bytes,
+    verify_token as verify_token_bytes,
+    SIGNATURE_LEN,
+)
 
-from .schemas import EmbedRequest, ExtractRequest
+from .schemas import ExtractRequest, SignRequest, VerifyRequest
 
 app = FastAPI(title="DRM Stego API", version="0.1.0")
 
@@ -12,16 +17,32 @@ def health():
     return {"ok": True}
 
 @app.post("/embed")
-async def embed(img: UploadFile, req: EmbedRequest):
+async def embed(img: UploadFile, text: str = Form(...)):
     image = Image.open(BytesIO(await img.read())).convert("RGB")
-    stego = LSBStego().embed(image, req.text.encode("utf-8"))
+    stego = LSBStego().embed(image, text.encode("utf-8"))
     buf = BytesIO()
     stego.save(buf, format="PNG")
     buf.seek(0)
-    return {"image_bytes": list(buf.getvalue()), "length": len(req.text.encode('utf-8'))}
+    return {"image_bytes": list(buf.getvalue()), "length": len(text.encode('utf-8'))}
 
 @app.post("/extract")
 async def extract(img: UploadFile, req: ExtractRequest):
     image = Image.open(BytesIO(await img.read())).convert("RGB")
     data = LSBStego().extract(image, length_bytes=req.length)
     return {"text": data.decode("utf-8", errors="ignore")}
+
+
+@app.post("/sign")
+async def sign(req: SignRequest):
+    token = sign_token_bytes(req.payload.encode("utf-8"))
+    return {"token_hex": token.hex()}
+
+
+@app.post("/verify")
+async def verify(req: VerifyRequest):
+    token = bytes.fromhex(req.token_hex)
+    valid = verify_token_bytes(token)
+    payload = (
+        token[:-SIGNATURE_LEN].decode("utf-8", errors="ignore") if valid else None
+    )
+    return {"valid": valid, "payload": payload}

--- a/src/server/schemas.py
+++ b/src/server/schemas.py
@@ -1,7 +1,12 @@
 from pydantic import BaseModel
 
-class EmbedRequest(BaseModel):
-    text: str
-
 class ExtractRequest(BaseModel):
     length: int
+
+
+class SignRequest(BaseModel):
+    payload: str
+
+
+class VerifyRequest(BaseModel):
+    token_hex: str

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,5 +13,5 @@ def test_embed_extract():
     img = Image.new("RGB", (64,64), color=(100,100,100))
     buf = BytesIO(); img.save(buf, format="PNG"); buf.seek(0)
     r = client.post("/embed", files={"img": ("a.png", buf.getvalue(), "image/png")},
-                    json={"text":"abc"})
+                    data={"text": "abc"})
     assert r.status_code == 200

--- a/tests/test_license_token.py
+++ b/tests/test_license_token.py
@@ -1,0 +1,37 @@
+from drmstego.drm.license_token import sign_token, verify_token, SIGNATURE_LEN
+from drmstego.cli import app as cli_app
+from typer.testing import CliRunner
+from fastapi.testclient import TestClient
+from src.server.main import app as api_app
+
+
+def test_sign_verify_functions():
+    payload = b"hello"
+    token = sign_token(payload)
+    assert verify_token(token)
+    assert token[:-SIGNATURE_LEN] == payload
+    tampered = bytearray(token)
+    tampered[0] ^= 0x01
+    assert not verify_token(bytes(tampered))
+
+
+def test_cli_sign_verify():
+    runner = CliRunner()
+    res = runner.invoke(cli_app, ["sign-token", "hello"])
+    assert res.exit_code == 0
+    token_hex = res.stdout.strip()
+    res2 = runner.invoke(cli_app, ["verify-token", token_hex])
+    assert "有效签名" in res2.stdout
+    assert "hello" in res2.stdout
+
+
+def test_api_sign_verify():
+    client = TestClient(api_app)
+    r = client.post("/sign", json={"payload": "hello"})
+    assert r.status_code == 200
+    token_hex = r.json()["token_hex"]
+    r2 = client.post("/verify", json={"token_hex": token_hex})
+    assert r2.status_code == 200
+    data = r2.json()
+    assert data["valid"] is True
+    assert data["payload"] == "hello"


### PR DESCRIPTION
## Summary
- implement deterministic Ed25519 signing/verification for license tokens
- expose CLI and API commands to sign and verify tokens
- add tests for token signing via API and CLI, and fix LSB bit handling for NumPy 2

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b0604388e08322b227485bee244556